### PR TITLE
Clarify TMDB title usage in folder naming logic

### DIFF
--- a/utils/show_adder.py
+++ b/utils/show_adder.py
@@ -101,7 +101,7 @@ def add_show_interactively(
                     "overview": info.get("overview", "")
                 })
 
-            # Use LangChain to select best match and English name
+            # Use LangChain to select best TMDB match (folder name comes from TMDB details, not LLM show_name)
             try:
                 llm_response: ShowMatch = llm_chains.match_show(show_name, candidates_for_llm)
                 logger.debug(f"LLM Branch - LangChain response: {llm_response}")
@@ -145,18 +145,37 @@ def add_show_interactively(
                 if not details or "info" not in details:
                     logger.exception(f"LLM Branch Fallback - Failed to retrieve full details for TMDB ID {tmdb_id}")
                     raise ValueError(f"LLM Branch Fallback - Failed to retrieve full details for TMDB ID {tmdb_id}")
-                # Sanitize sys_name to keep consistency with the LLM success path
-                sys_name = sanitize_filename(show_name)
-                # Proceed with fallback path
+                # Folder name from TMDB localized title (same source as Show.tmdb_name), not user query —
+                # matches non-LLM branch when TMDB returns English titles for non-Latin originals.
+                fb_info = details["info"]
+                sys_name = (
+                    fb_info.get("name")
+                    or fb_info.get("original_name")
+                    or first_result.get("name", show_name)
+                )
+                logger.debug(
+                    f"LLM Branch Fallback - Using TMDB title '{sys_name}' for folder"
+                )
             else:
-                # Use LLM to set the tmdb_id and sys_name vars
                 tmdb_id = llm_response_dict["tmdb_id"]
-                sys_name = sanitize_filename(llm_response_dict["show_name"])
                 details = tmdb.get_show_details(tmdb_id)
-                
+
                 if not details or "info" not in details:
                     logger.exception(f"LLM Branch - Failed to retrieve full details for TMDB ID {tmdb_id}")
                     raise ValueError(f"LLM Branch - Failed to retrieve full details for TMDB ID {tmdb_id}")
+                # LLM picks tmdb_id; folder name follows TMDB localized title (info.name), not LLM show_name,
+                # so directories stay English when TMDB name is English but the model echoes original_language titles.
+                info = details["info"]
+                sys_name = (
+                    info.get("name")
+                    or info.get("original_name")
+                    or llm_response_dict.get("show_name")
+                    or show_name
+                )
+                logger.debug(
+                    f"LLM Branch - Using TMDB title '{sys_name}' for folder "
+                    f"(LLM show_name was '{llm_response_dict.get('show_name')}')"
+                )
             
         elif show_name:
             logger.info("Using show_name branch")

--- a/utils/show_adder.py
+++ b/utils/show_adder.py
@@ -151,7 +151,8 @@ def add_show_interactively(
                 sys_name = (
                     fb_info.get("name")
                     or fb_info.get("original_name")
-                    or first_result.get("name", show_name)
+                    or first_result.get("name")
+                    or show_name
                 )
                 logger.debug(
                     f"LLM Branch Fallback - Using TMDB title '{sys_name}' for folder"


### PR DESCRIPTION
- Update comments to specify that folder names are derived from TMDB details rather than LLM show_name
- Adjust fallback logic to prioritize TMDB localized titles for consistency in folder naming
- Enhance logging to reflect the source of the folder name, improving traceability in the LLM branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `sys_name` (and thus folder paths and DB existence checks) are derived in the LLM branch, which could rename/redirect created directories for some shows. Logic is straightforward but impacts filesystem structure and potential duplicates.
> 
> **Overview**
> Aligns folder naming in the LLM-assisted add flow to always come from TMDB show details rather than the LLM-returned `show_name` or the original query.
> 
> In both the low-confidence fallback and the successful LLM path, `sys_name` is now selected from TMDB’s `info.name`/`original_name` (with sensible fallbacks) and adds debug logging to trace which title source was used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05aee287f7999abcc3c84af485917cada16f1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->